### PR TITLE
Escaping column names in case column is a SQL reserved keyword

### DIFF
--- a/classes/task/helper.php
+++ b/classes/task/helper.php
@@ -383,9 +383,9 @@ EOF;
         $fields = [];
         foreach ($fieldlist as $index => $field) {
             if (is_int($index)) {
-                $fields[] = $field;
+                $fields[] = "\"$field\"";
             } else {
-                $fields[] = "{$index} AS {$field}";
+                $fields[] = "\"{$index}\" AS {$field}";
             }
         }
         $fields = !empty($fields) ? implode(',', $fields) : "*";
@@ -394,11 +394,11 @@ EOF;
             foreach ($conditions as $key=>$value) {
                 $value = $this->db_encode($this->db_addslashes($value));
 
-                $where[] = "$key = '$value'";
+                $where[] = "\"$key\" = '$value'";
             }
         }
         $where = $where ? "WHERE ".implode(" AND ", $where) : "";
-        $sort = $sort ? "ORDER BY $sort" : "";
+        $sort = $sort ? "ORDER BY \"$sort\"" : "";
         $distinct = $distinct ? "DISTINCT" : "";
         $sql = "SELECT $distinct $fields
                   FROM $table


### PR DESCRIPTION
Hello there,
this is just a small fix. I had a column named 'group' and the SQL failed cause it's a reserved keyword. This quick fix adds quotes to all column names in SQL.
