### PR TITLE
sending id to group_update

### DIFF
--- a/classes/task/helper.php
+++ b/classes/task/helper.php
@@ -200,6 +200,7 @@ EOF;
                 $localgroup = $localgroups[$idnumber];
                 if ($localgroup->name !== $name) {
                     // Update it.
+                    $data->id = $localgroup->id;
                     $trace->output("Updating group {$name} in {$courseid} with idnumber {$idnumber}");
                     groups_update_group($data);
                 }


### PR DESCRIPTION
Hello Dan,
this is a simple fix - `groups_update_group` function requires id to be present in $data [on line 439](https://github.com/moodle/moodle/blob/main/group/lib.php#L439)

Martin